### PR TITLE
Pull Request: Add Optional Username and Password Fields for OpenVPN Authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,5 @@ Add better logs so if there is an issue you will see it more prominently.
 ## Fixing it!
 # 2.0.3
 Final check it's all good to update fully now! The new client location is in the /config directory!
+# 2.0.4
+Add user and password management from configuration tab if ovpn required authentication

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "name": "OpenVPN Client",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "slug": "openvpn_client",
   "description": "A secure way to send your data through any OpenVPN Server",
   "url": "https://github.com/MapGuy11/homeassistant-openvpn-client-addon",
@@ -11,10 +11,14 @@
   "host_network": true,
   "privileged": ["NET_ADMIN"],
   "options": {
-    "ovpnfile": "client.ovpn"
+    "ovpnfile": "client.ovpn",
+    "username": "",
+    "password": ""
   },
   "schema": {
-    "ovpnfile": "str"
+    "ovpnfile": "str",
+    "username": "str",
+    "password": "str"
   },
   "map" : ["config:ro"]
 }

--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,9 @@ OPENVPN_CONFIG_PATH=/config
 OVPNFILE="$(jq --raw-output '.ovpnfile' $CONFIG_PATH)"
 OPENVPN_CONFIG=/config/${OVPNFILE}
 
+USERNAME="$(jq --raw-output '.username' $CONFIG_PATH)"
+PASSWORD="$(jq --raw-output '.password' $CONFIG_PATH)"
+
 ########################################################################################################################
 # Initialize the tun interface for OpenVPN if not already available
 # Arguments:
@@ -16,7 +19,6 @@ OPENVPN_CONFIG=/config/${OVPNFILE}
 ########################################################################################################################
 function init_tun_interface(){
     # create the tunnel for the OpenVPN client
-
     mkdir -p /dev/net
     if [ ! -c /dev/net/tun ]; then
         mknod /dev/net/tun c 10 200
@@ -49,8 +51,6 @@ function check_files_available(){
     else
         return 1
     fi
-
-
 }
 
 ########################################################################################################################
@@ -64,11 +64,9 @@ function check_files_available(){
 #   None
 ########################################################################################################################
 function wait_configuration(){
-
     echo "Waiting for user to put the OpenVPN configuration file in ${OPENVPN_CONFIG_PATH}"
     # therefore, wait until the user upload the required certification files
     while true; do
-
         check_files_available
 
         if [[ $? == 0 ]]
@@ -86,15 +84,27 @@ init_tun_interface
 # wait until the user uploaded the configuration files
 wait_configuration
 
-echo""
-echo""
+echo ""
+echo ""
 echo "Setting up the VPN connection with the following OpenVPN configuration: ${OPENVPN_CONFIG}"
-echo""
-echo""
+echo ""
+echo ""
 
-echo"Trying to connect to your OpenVPN server using, ${OPENVPN_CONFIG}"
-echo""
-echo""
+AUTH_FILE="/etc/openvpn/auth.txt"
 
-# try to connect to the server using the used defined configuration
-openvpn --config ${OPENVPN_CONFIG}
+if [[ -n "$USERNAME" ]] && [[ -n "$PASSWORD" ]]; then
+    echo "Using provided username and password"
+    echo "$USERNAME" > $AUTH_FILE
+    echo "$PASSWORD" >> $AUTH_FILE
+    chmod 600 $AUTH_FILE
+    AUTH_OPTION="--auth-user-pass $AUTH_FILE"
+else
+    echo "No username and password provided, skipping auth-user-pass"
+    AUTH_OPTION=""
+fi
+
+echo "Trying to connect to your OpenVPN server using, ${OPENVPN_CONFIG}"
+echo ""
+
+# try to connect to the server using the user-defined configuration and credentials (if provided)
+openvpn --config ${OPENVPN_CONFIG} $AUTH_OPTION


### PR DESCRIPTION
#### Description:
This PR introduces the ability to optionally provide `username` and `password` for OpenVPN connections that require user authentication. If these fields are not provided, OpenVPN will still run without the `--auth-user-pass` option, ensuring compatibility with configurations that do not require user credentials.

#### Changes:
1. **`config.json` Updates:**
   - Added `username` and `password` fields to the configuration schema, allowing users to optionally input their VPN credentials via the Home Assistant UI.

   ```json
   "options": {
       "ovpnfile": "client.ovpn",
       "username": "",
       "password": ""
   },
   "schema": {
       "ovpnfile": "str",
       "username": "str",
       "password": "str"
   }
   ````

2. **`run.sh` Updates:**
   - Modified the `run.sh` script to:
      - Check if the `username` and `password` are provided.
      - Create an `auth.txt` file containing the credentials only if both `username` and `password` are provided.
      - Add the `--auth-user-pass` option to the OpenVPN command when credentials are provided.
      - Run OpenVPN without the `--auth-user-pass` option if credentials are not supplied, allowing it to function with configurations that don’t require authentication.
   ```bash
   if [[ -n "$USERNAME" ]] && [[ -n "$PASSWORD" ]]; then
       echo "$USERNAME" > $AUTH_FILE
       echo "$PASSWORD" >> $AUTH_FILE
       AUTH_OPTION="--auth-user-pass $AUTH_FILE"
   else
       AUTH_OPTION=""
   fi

   openvpn --config ${OPENVPN_CONFIG} $AUTH_OPTION
   ````
   
#### Impact:
   - These changes provide flexibility to users who either have VPN configurations that require authentication via `username` and `password` or those who do not.
   - If the `username` and `password` fields are left blank, OpenVPN will proceed without the need for credentials.