### PR TITLE
Pull Request: Add optional passphrase field for OpenVPN tls authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,5 @@ Add better logs so if there is an issue you will see it more prominently.
 Final check it's all good to update fully now! The new client location is in the /config directory!
 # 2.0.4
 Add user and password management from the configuration tab if the OVPN server requires authentication. Thank you [@Izakun](https://github.com/Izakun) for the contribution!
+# 2.0.5
+Add passphrase management from the configuration tab if the .ovpn have a tls-auth


### PR DESCRIPTION
This PR updates the OpenVPN connection script to support three modes of authentication:

- No authentication: Direct connection using the .ovpn file.
- Username/password authentication: Uses credentials from the config tab.
- Private key passphrase: Use a passphrase for the private key, if specified in config tab.